### PR TITLE
Add rate-limiting; inline reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,53 @@ or via syslog APIs.
 
 Periodically, it will report statistics about the rate at which it has
 generated the output. It offers an ability to adjust how often it
-reports, and where to issue the reports. Once can ask for reports
-inline, to stderr, another file, or via syslog.
+reports, and where to issue the reports. One can ask for reports to
+stdout, to stderr, another file, or via syslog.
 
-The size of the log lines is a parameter to the program, as well as
-whether to generate them all of the same size, or using a Gaussian
-distribution with the size being the mean and a providing an optional
-standard deviation.
+The size of the log lines is an optional parameter to the program, as
+well as whether to generate them all of a fixed size, or using a
+Gaussian distribution, with the size being the mean, optionally
+providing the standard deviation.
 
 One can provide a unique ID for the instance of the loader to embed in
-the generated output, or it will generate a 32 character UUID by
-default.
+the generated output. Without one provided the loader will generate a 32
+character UUID by default.
 
 The `verify-loader` program in turn accepts a sequence of lines as
-emitted by one or more the `loader` programs, and verifies they emitted
+emitted by one or more the `loader` programs, and verifies the emitted
 lines are receives in order, without any duplicates or skipped lines.
+
+## Example Usage:
+
+Emit logging load to `/dev/null`:
+```
+$ ./loader --output=/dev/null --report=stderr
+loader stat: 0000010000   1894.830   1894.830
+loader stat: 0000020000   1903.279   1899.045
+loader stat: 0000030000   1896.060   1898.049
+loader stat: 0000040000   1900.117   1898.565
+loader stat: 0000050000   1880.544   1894.934
+```
+
+Rate-limit to 10 per second, reporting every 40 logs entries:
+```
+$ ./loader --output=/dev/null --report=stderr --msgpersec=10 --report-interval=40
+loader stat: 0000000040     10.242     10.242
+loader stat: 0000000080     10.000     10.119
+loader stat: 0000000120      9.998     10.079
+loader stat: 0000000160     10.003     10.060
+loader stat: 0000000200     10.006     10.049
+```
+
+Simple emission of lines to stdout and have the sequence verified:
+```
+$ ./loader | ./verify-loader
+ 8f8f2882e66643d08c205804f7f5540a : 100 0 0
+ 8f8f2882e66643d08c205804f7f5540a : 200 0 0
+ 8f8f2882e66643d08c205804f7f5540a : 300 0 0
+ 8f8f2882e66643d08c205804f7f5540a : 400 0 0
+ 8f8f2882e66643d08c205804f7f5540a : 500 0 0
+.
+.
+.
+```

--- a/loader
+++ b/loader
@@ -59,7 +59,7 @@ def msgsizgen_gaussian(mean, stddev = DEFAULT_STDDEV):
 dist_methods = { 'fixed': msgsizgen_fixed, 'gaussian': msgsizgen_gaussian, 'normal': msgsizgen_gaussian }
 
 
-def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=(10000,1), seq_width=10, chars=string.ascii_lowercase + string.digits):
+def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=(10000,1), seq_width=10, chars=string.ascii_lowercase + string.digits, msgpersec=0):
     '''Emit a formatted payload of random bytes, using a Gaussian
        distribution using a given size as the mean.  The payload
        is emitted using the output_method function, while statistics
@@ -83,6 +83,10 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
     prefix = "loader seq - %s - " % invocid
     prefix_len = len(prefix)
     sub_len = (prefix_len + seq_width + sep_len)
+    if msgpersec > 0:
+        msgperiod = (1/msgpersec, time.time() + 1/msgpersec, msgpersec)
+    else:
+        msgperiod = None
     try:
         for asize in msgsizgen(size, stddev):
             asize -= sub_len
@@ -97,11 +101,32 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
                 if (diff > report_interval[1]):
                     msg_rate = msgs / diff
                     total_msg_rate = seq / (now - start)
-                    report_method("loader stat: %0*d %10.2f %10.2f" % (seq_width, seq, msg_rate, total_msg_rate))
+                    if msgperiod:
+                        if msg_rate < (msgperiod[2] - 0.50):
+                            notice = " (too slow, %.4f)" % msgperiod[2]
+                        elif msg_rate > (msgperiod[2] + 0.50):
+                            notice = " (too fast, %.4f)" % msgperiod[2]
+                        else:
+                            notice = ""
+                    else:
+                        notice = ""
+                    report_method("loader stat: %0*d %10.3f%s %10.3f" % (seq_width, seq, msg_rate, notice, total_msg_rate))
                     past = now
                     msgs = 0
+            if msgperiod is not None:
+                now = time.time()
+                if now >= msgperiod[1]:
+                    # We have exited our rate-limit window, calculate next
+                    # window and continue
+                    msgperiod = (msgperiod[0], msgperiod[1] + msgperiod[0], msgperiod[2])
+                # Wait until our window is up
+                sleep_window = msgperiod[1] - now
+                while now < msgperiod[1]:
+                    time.sleep(sleep_window)
+                    now = time.time()
     except KeyboardInterrupt:
         pass
+
 
 if __name__ == '__main__':
     log = logging.getLogger(__name__)
@@ -130,6 +155,46 @@ if __name__ == '__main__':
     parser.add_argument('--stddev', metavar='STDDEV', dest='stddev', type=float,
             default=DEFAULT_STDDEV,
             help='the standard deviation to use with a random distribution (defaults to 32)')
+    parser.add_argument('--output', metavar='METHOD', dest='output', action='store',
+            default='stdout',
+            help='where to emit the output, one of: "stdout", "stderr", "syslog", "<file name>" (defaults to "stdout")')
+    parser.add_argument('--report', metavar='METHOD', dest='report', action='store',
+            default='stderr',
+            help='where to emit the report output, one of: "stdout", "stderr", "syslog", "<file name>" (defaults to "stderr")')
+    parser.add_argument('--msgpersec', metavar='MSGPERSEC', dest='msgpersec', type=float,
+            default=0,
+            help='the # of logs per second (floating point) to emit (defaults to 0, unlimited)')
+    parser.add_argument('--report-interval', metavar='INTERVAL', dest='reportint', type=int,
+            default=10000,
+            help='the # of messages between reports (defaults to 10,000)')
     args = parser.parse_args()
 
-    load(args.invocid, args.payload_size, print, log.info, dist=args.payload_dist, stddev=args.stddev)
+    # Determine the output method to emit logs
+    if args.output == 'syslog':
+        output_method = log.debug
+    else:
+        if args.output in ('stderr', 'stdout'):
+            ofp = getattr(sys, args.output)
+        else:
+            # Assume the parameter is a file name
+            ofp = open(args.output, "w")
+        def output_closure(payload):
+            ofp.write(payload + '\n')
+        output_method = output_closure
+
+    # Determine the report method to use
+    if args.report == 'syslog':
+        report_method = log.info
+    else:
+        if args.report in ('stderr', 'stdout'):
+            rfp = getattr(sys, args.report)
+        else:
+            # Assume the parameter is a file name
+            rfp = open(args.report, "w")
+        def report_closure(payload):
+            rfp.write(payload + '\n')
+        report_method = report_closure
+
+    load(args.invocid, args.payload_size, output_method, report_method,
+            dist=args.payload_dist, stddev=args.stddev, msgpersec=args.msgpersec,
+            report_interval=(args.reportint, 1))

--- a/loader
+++ b/loader
@@ -77,9 +77,6 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
     msgsizgen = dist_methods[dist]
     sep = ' - '
     sep_len = len(sep)
-    seq = 0
-    start = past = time.time()
-    msgs = 0
     prefix = "loader seq - %s - " % invocid
     prefix_len = len(prefix)
     sub_len = (prefix_len + seq_width + sep_len)
@@ -87,32 +84,58 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
         msgperiod = (1/msgpersec, time.time() + 1/msgpersec, msgpersec)
     else:
         msgperiod = None
+
+
+    class StatsCtx(object):
+
+        def __init__(self):
+            self.start = self.past = time.time()
+            self.seq = 0
+            self.msgs = 0
+
+        def statstr(self, now, msgperiod):
+            msg_rate = self.msgs / (now - self.past)
+            total_msg_rate = self.seq / (now - self.start)
+            if msgperiod:
+                if msg_rate < (msgperiod[2] - 0.50):
+                    notice = " (too slow, %.4f)" % msgperiod[2]
+                elif msg_rate > (msgperiod[2] + 0.50):
+                    notice = " (too fast, %.4f)" % msgperiod[2]
+                else:
+                    notice = ""
+            else:
+                notice = ""
+            self.past = now
+            self.msgs = 0
+            return "%.3fs %0*d %10.3f%s %10.3f" % (now, seq_width, self.seq, msg_rate, notice, total_msg_rate)
+
+    stats = StatsCtx()
     try:
         for asize in msgsizgen(size, stddev):
             asize -= sub_len
-            asize = 1 if asize <= 0 else asize
-            msg = ''.join(random.choice(chars) for x in range(asize))
-            seq += 1
-            msgs += 1
-            output_method("%s%0*d%s%s" % (prefix, seq_width, seq, sep, msg))
-            if seq % report_interval[0] == 0:
+            stats.seq += 1
+            stats.msgs += 1
+            if report_method is None and (stats.seq % report_interval[0]) == 0:
+                # Reporting is done inline as part of a sequence message.
                 now = time.time()
-                diff = now - past
-                if (diff > report_interval[1]):
-                    msg_rate = msgs / diff
-                    total_msg_rate = seq / (now - start)
-                    if msgperiod:
-                        if msg_rate < (msgperiod[2] - 0.50):
-                            notice = " (too slow, %.4f)" % msgperiod[2]
-                        elif msg_rate > (msgperiod[2] + 0.50):
-                            notice = " (too fast, %.4f)" % msgperiod[2]
-                        else:
-                            notice = ""
-                    else:
-                        notice = ""
-                    report_method("loader stat: %0*d %10.3f%s %10.3f" % (seq_width, seq, msg_rate, notice, total_msg_rate))
-                    past = now
-                    msgs = 0
+                if (now - stats.past > report_interval[1]):
+                    stats_msg = "(stats: %s) " % stats.statstr(now, msgperiod)
+                    stats_msg_len = len(stats_msg)
+                else:
+                    stats_msg = ""
+                    stats_msg_len = 0
+            else:
+                stats_msg = ""
+                stats_msg_len = 0
+            asize -= stats_msg_len
+            asize = 1 if asize <= 0 else asize
+            msg = stats_msg + ''.join(random.choice(chars) for x in range(asize))
+            output_method("%s%0*d%s%s" % (prefix, seq_width, stats.seq, sep, msg))
+            if report_method is not None and (stats.seq % report_interval[0]) == 0:
+                # Reporting is done out-of-band.
+                now = time.time()
+                if (now - stats.past > report_interval[1]):
+                    report_method("loader stat: %s" % stats.statstr(now, msgperiod))
             if msgperiod is not None:
                 now = time.time()
                 if now >= msgperiod[1]:
@@ -159,8 +182,8 @@ if __name__ == '__main__':
             default='stdout',
             help='where to emit the output, one of: "stdout", "stderr", "syslog", "<file name>" (defaults to "stdout")')
     parser.add_argument('--report', metavar='METHOD', dest='report', action='store',
-            default='stderr',
-            help='where to emit the report output, one of: "stdout", "stderr", "syslog", "<file name>" (defaults to "stderr")')
+            default='inline',
+            help='where to emit the report output, one of: "inline", "stdout", "stderr", "syslog", "<file name>" (defaults to "inline")')
     parser.add_argument('--msgpersec', metavar='MSGPERSEC', dest='msgpersec', type=float,
             default=0,
             help='the # of logs per second (floating point) to emit (defaults to 0, unlimited)')
@@ -183,7 +206,9 @@ if __name__ == '__main__':
         output_method = output_closure
 
     # Determine the report method to use
-    if args.report == 'syslog':
+    if args.report == 'inline':
+        report_method = None
+    elif args.report == 'syslog':
         report_method = log.info
     else:
         if args.report in ('stderr', 'stdout'):


### PR DESCRIPTION
Add support for stats report inline w msg payload

Implement output and reporting methods, rate limiting:

 * The previously documented, but unimplemented, methods of output and
reporting have now been implemented.

 * We also add the ability to rate-limit the output, and change the
reporting interval (as the default of 10,000 is not always desired for
different output rates).

 * We also update the README with some examples, and apply a few
corrections to the text.

