### PR TITLE
Add a total cap for logs emitted in MBs and an optional payload generator choice

### DIFF
--- a/loader
+++ b/loader
@@ -113,7 +113,7 @@ class StatsCtx(object):
 dist_methods = { 'fixed': msgsizgen_fixed, 'gaussian': msgsizgen_gaussian, 'normal': msgsizgen_gaussian }
 
 
-def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=10, seq_width=10, chars=string.ascii_lowercase + string.digits, msgpersec=0):
+def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=10, seq_width=10, chars=string.ascii_lowercase + string.digits, msgpersec=0, total_size=0):
     '''Emit a formatted payload of random bytes, using a Gaussian
        distribution using a given size as the mean.  The payload
        is emitted using the output_method function, while statistics
@@ -139,7 +139,7 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
     try:
         for asize, seq, report in msgsizgen(stats, size, stddev):
             asize -= sub_len
-            if report_method is None and report:
+            if report_method is None and (report or stats.total_size > total_size * (1024 * 1024)):
                 # Reporting is done inline as part of a sequence message payload.
                 stats_msg = "(stats: %s) " % stats.statstr(seq_width)
                 stats_msg_len = len(stats_msg)
@@ -153,6 +153,12 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
             if report_method is not None and report:
                 # Reporting is done out-of-band.
                 report_method("loader stat: %s" % stats.statstr(seq_width))
+            if stats.total_size > total_size * (1024 * 1024):
+                # We're done
+                if report_method is not None and not report:
+                    # Reporting is done out-of-band.
+                    report_method("loader stat: %s" % stats.statstr(seq_width))
+                break
     except KeyboardInterrupt:
         pass
 
@@ -196,6 +202,9 @@ if __name__ == '__main__':
     parser.add_argument('--report-interval', metavar='INTERVAL', dest='reportint', type=int,
             default=10,
             help='the # of megabytes of message data between reports (defaults to 10 MB)')
+    parser.add_argument('--total-size', metavar='TOTSIZE', dest='totalsize', type=int,
+            default=0,
+            help='the total # of megabytes to generate before ending (defaults to 0, unlimited)')
     args = parser.parse_args()
 
     # Determine the output method to emit logs
@@ -228,4 +237,4 @@ if __name__ == '__main__':
 
     load(args.invocid, args.payload_size, output_method, report_method,
             dist=args.payload_dist, stddev=args.stddev, msgpersec=args.msgpersec,
-            report_interval=args.reportint)
+            report_interval=args.reportint, total_size=args.totalsize)

--- a/loader
+++ b/loader
@@ -56,6 +56,9 @@ def msgsizgen_gaussian(stats, mean, stddev = DEFAULT_STDDEV):
         yield stats.nextseq(int(round(randomizer.gauss(mean, stddev))))
 
 
+dist_methods = { 'fixed': msgsizgen_fixed, 'gaussian': msgsizgen_gaussian, 'normal': msgsizgen_gaussian }
+
+
 class StatsCtx(object):
 
     def __init__(self, msgpersec, rptint):
@@ -110,10 +113,19 @@ class StatsCtx(object):
         return "%.3fs %0*d %10.3f%s %10.3f" % (now, seq_width, self.seq, msg_rate, notice, total_msg_rate)
 
 
-dist_methods = { 'fixed': msgsizgen_fixed, 'gaussian': msgsizgen_gaussian, 'normal': msgsizgen_gaussian }
+chars = string.ascii_lowercase + string.digits
+def payload_random(size):
+    return ''.join(random.choice(chars) for x in range(size))
 
 
-def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=10, seq_width=10, chars=string.ascii_lowercase + string.digits, msgpersec=0, total_size=0):
+def payload_fixed(size):
+    return 'x' * size
+
+
+gen_methods = { 'fixed': payload_fixed, 'random': payload_random }
+
+
+def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=10, seq_width=10, msgpersec=0, total_size=0, payload_gen='random'):
     '''Emit a formatted payload of random bytes, using a Gaussian
        distribution using a given size as the mean.  The payload
        is emitted using the output_method function, while statistics
@@ -129,6 +141,7 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
        facilitate finding the output emitted by this instance.
     '''
     msgsizgen = dist_methods[dist]
+    payloadgen = gen_methods[payload_gen]
     sep = ' - '
     sep_len = len(sep)
     prefix = "loader seq - %s - " % invocid
@@ -139,7 +152,7 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
     try:
         for asize, seq, report in msgsizgen(stats, size, stddev):
             asize -= sub_len
-            if report_method is None and (report or stats.total_size > total_size * (1024 * 1024)):
+            if report_method is None and (report or (total_size > 0 and stats.total_size > total_size * (1024 * 1024))):
                 # Reporting is done inline as part of a sequence message payload.
                 stats_msg = "(stats: %s) " % stats.statstr(seq_width)
                 stats_msg_len = len(stats_msg)
@@ -148,12 +161,12 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
                 stats_msg_len = 0
             asize -= stats_msg_len
             asize = 1 if asize <= 0 else asize
-            msg = stats_msg + ''.join(random.choice(chars) for x in range(asize))
+            msg = stats_msg + payloadgen(asize)
             output_method("%s%0*d%s%s" % (prefix, seq_width, seq, sep, msg))
             if report_method is not None and report:
                 # Reporting is done out-of-band.
                 report_method("loader stat: %s" % stats.statstr(seq_width))
-            if stats.total_size > total_size * (1024 * 1024):
+            if total_size > 0 and (stats.total_size > total_size * (1024 * 1024)):
                 # We're done
                 if report_method is not None and not report:
                     # Reporting is done out-of-band.
@@ -184,6 +197,9 @@ if __name__ == '__main__':
     parser.add_argument('--distribution', metavar='DIST', dest='payload_dist', action='store',
             default='gaussian', choices=dist_methods,
             help='the size distribution to use, e.g. "gaussian" (default), "normal" (alias for gaussian), or "fixed"')
+    parser.add_argument('--payload-gen', metavar='GEN', dest='payload_gen', action='store',
+            default='random', choices=gen_methods,
+            help='the payload generator to use, e.g. "random" (default), or "fixed"')
     parser.add_argument('--invocid', metavar='INVOCID', dest='invocid', action='store',
             default=uuid.uuid4().hex,
 			help='the unique invocation ID string to use (defaults to 32 char generated one)')
@@ -237,4 +253,5 @@ if __name__ == '__main__':
 
     load(args.invocid, args.payload_size, output_method, report_method,
             dist=args.payload_dist, stddev=args.stddev, msgpersec=args.msgpersec,
-            report_interval=args.reportint, total_size=args.totalsize)
+            report_interval=args.reportint, total_size=args.totalsize,
+            payload_gen=args.payload_gen)


### PR DESCRIPTION
In order to script consistently we allow a total cap to the number of megabytes generated by the load driver.  This let's us generate 200 MB of data for each invocation of the driver with different parameters and have run times which are approximately the same (not the case when we change the rate-limit, though).

The random payload generation costs us CPU to use, and limits the rate at which we can generate data.  While that is great for representing a workload in some cases, it means we can't use the load driver in situations requiring higher stress levels.  As a result, we add the ability to change the payload generator so that we use substantially less CPU to raise the message rate.