### PR TITLE
add support for verify-loader to look for loader seq in a substring

### DIFF
--- a/verify-loader
+++ b/verify-loader
@@ -22,11 +22,15 @@ import os
 import time
 import argparse
 import signal
+import re
+import json
 from collections import defaultdict
 
 REPORT_INTERVAL = 10
 MB = 1024 * 1024
 
+# payload has chars = string.ascii_lowercase + string.digits
+payloadre = re.compile(r'( [a-z0-9]+)')
 # if running verify-loader as a background process,
 # we can still do a kill -2 $pid to make it exit
 # the main loop and print the stats
@@ -35,55 +39,137 @@ def handle_sig_int(signum, frame):
 
 signal.signal(signal.SIGINT, handle_sig_int)
 
+class VerifyRecord(object):
+    line = None
+    linelen = 0
+    msg = None
+    msglen = 0
+    payload = None
+    payloadlen = 0
+    invocid = None
+    seq = 0
+
+    def __init__(self, line, linelen):
+        trimpayload = False
+        if line.startswith('loader seq - '):
+            msg = line
+        else:
+            idx = line.find('@cee:{')
+            if idx >= 0:
+                try:
+                    msg = json.loads(line[idx+5:]).get('message', None)
+                except Exception:
+                    print "error parsing json", line[idx+5:]
+                    msg = None
+                if not getattr(msg, 'startswith', None) or not msg.startswith('loader seq - '):
+                    # if using cee, there must be a message field, and the contents of that
+                    # field must be the loader message and nothing else
+                    msg = None
+            else:
+                idx = line.find('loader seq - ')
+                if idx >= 0:
+                    msg = line[idx:]
+                    # payload may have extra metadata at the end
+                    trimpayload = True
+                else:
+                    msg = None
+        if msg:
+            try:
+                ary = msg.split('-')
+                invocid, seqval, payload = ary[1:4]
+                seq = int(seqval)
+                msglen = len(msg)
+                if trimpayload:
+                    pm = payloadre.match(payload)
+                    if pm:
+                        msglen -= len(payload)
+                        payload = pm.group(1)
+                        msglen += len(payload)
+                self.line = line
+                self.linelen = linelen
+                self.msg = msg
+                self.msglen = msglen
+                self.payload = payload
+                self.payloadlen = len(payload)
+                self.invocid = invocid.strip()
+                self.seq = seq
+            except Exception:
+                pass
+
+    def __bool__(self):
+        return self.line is not None
+    __nonzero__ = __bool__
+
+    def __str__(self):
+        return '{0} {1} {2}'.format(self.invocid, self.seq, self.payload)
+
+# for debugging
+print_duplicates = False
 class Context(object):
 
     def __init__(self):
         self.prev = None
         self.count = 0
         self.bytes = 0
+        self.msg_bytes = 0
+        self.payload_bytes = 0
         self.report_count = 0
         self.report_bytes = 0
+        self.report_msg_bytes = 0
+        self.report_payload_bytes = 0
         self.duplicates = 0
         self.skips = 0
 
-    def msg(self, seq, length):
+    def msg(self, record):
         self.report_count += 1
-        self.report_bytes += length
+        self.report_bytes += record.linelen
+        self.report_msg_bytes += record.msglen
+        self.report_payload_bytes += record.payloadlen
 
         if self.prev is None:
-            self.prev = seq
+            self.prev = record.seq
             return None
-        elif seq == (self.prev + 1):
+        elif record.seq == (self.prev + 1):
             # normal and expected code path
-            self.prev = seq
+            self.prev = record.seq
             return None
         else:
             ret_prev = self.prev
-            if seq <= self.prev:
+            if record.seq <= self.prev:
                 self.duplicates += 1
+                if print_duplicates:
+                    print "duplicate record: ", record.line
             else:
-                assert seq > (self.prev + 1), "Logic bomb! Should not be possible"
+                assert record.seq > (self.prev + 1), "Logic bomb! Should not be possible"
                 self.skips += 1
                 # Since the sequence jumped ahead, save the new value as the
                 # previous in order to be sure to stay with the jump.
-                self.prev = seq
+                self.prev = record.seq
             return ret_prev
 
     def report(self):
         if self.report_count > 0:
             self.count += self.report_count
             self.bytes += self.report_bytes
+            self.msg_bytes += self.report_msg_bytes
+            self.payload_bytes += self.report_payload_bytes
             self.report_count = 0
             self.report_bytes = 0
+            self.report_msg_bytes = 0
+            self.report_payload_bytes = 0
             ret_val = True
         else:
             ret_val = False
 
 
-def print_stats(invocid, ctx, payload):
+def print_stats(ctx, record):
     try:
-        stats, _ = payload.rsplit(' ', 1)
-        rawvals = stats.strip()[:-1].split(' ')
+        stats, _ = record.payload.rsplit(' ', 1)
+        idx = stats.find(')')
+        if idx < 1:
+            rawvals = stats.strip()[:-1].split(' ')
+        else:
+            rawvals = stats.strip()[:idx-1].split(' ')
         vals = []
         for val in rawvals:
             if val:
@@ -96,7 +182,7 @@ def print_stats(invocid, ctx, payload):
             print "Logic bomb!"
             sys.exit(1)
     except Exception:
-        print "Error: ", payload
+        print "Error: ", record.payload
         sys.stdout.flush()
     else:
         try:
@@ -105,14 +191,16 @@ def print_stats(invocid, ctx, payload):
             lclrate = float(lclrate)
             gblrate = float(gblrate)
         except Exception:
-            print "Error: ", payload
+            print "Error: ", record.payload
             sys.stdout.flush()
         else:
-            assert ctx.prev == statseq
+            if ctx.prev != statseq:
+                print "Error: ", record.payload
+                assert ctx.prev == statseq
             assert timestamp[-1] == 's'
             now = time.time()
             print "%s: %.2fs (%5.2fs) %12.3f %12.3f %d %d %d %d" % (
-                    invocid, ts, now - ts, lclrate, gblrate, statseq,
+                    record.invocid, ts, now - ts, lclrate, gblrate, statseq,
                     ctx.count, ctx.skips, ctx.duplicates)
             sys.stdout.flush()
 
@@ -127,6 +215,8 @@ def verify(input_gen, report_interval=REPORT_INTERVAL):
     report_bytes_target = report_interval * MB
     report_ignored_bytes = 0
     report_ignored_count = 0
+    report_msg_bytes = 0
+    report_payload_bytes = 0
 
     contexts = defaultdict(Context)
     start = time.time()
@@ -135,32 +225,22 @@ def verify(input_gen, report_interval=REPORT_INTERVAL):
     try:
         for line in input_gen:
             line_len = len(line)
-            if not line.startswith("loader seq - "):
+            record = VerifyRecord(line, line_len)
+            if not record:
                 report_ignored_bytes += line_len
                 report_ignored_count += 1
             else:
-                try:
-                    _, invocid, seqval, payload = line.split('-', 4)
-                except Exception:
-                    report_ignored_bytes += line_len
-                    report_ignored_count += 1
-                else:
-                    try:
-                        seq = int(seqval)
-                    except Exception:
-                        report_ignored_bytes += line_len
-                        report_ignored_count += 1
-                    else:
-                        report_bytes += line_len
-                        invocid = invocid.strip()
-                        ctx = contexts[invocid]
-                        prev = ctx.msg(seq, line_len)
-                        if prev is not None:
-                            # Bad record encountered, flag it
-                            print "%s: %d %d  <-" % (invocid, seq, prev)
-                            sys.stdout.flush()
-                        if payload.startswith(" (stats:"):
-                            print_stats(invocid, ctx, payload)
+                report_bytes += record.linelen
+                report_msg_bytes += record.msglen
+                report_payload_bytes += record.payloadlen
+                ctx = contexts[record.invocid]
+                prev = ctx.msg(record)
+                if prev is not None:
+                    # Bad record encountered, flag it
+                    print "%s: %d %d  <-" % (record.invocid, record.seq, prev)
+                    sys.stdout.flush()
+                if record.payload.startswith(" (stats:"):
+                    print_stats(ctx, record)
             if report_bytes_target > 0 and (report_bytes + report_ignored_bytes) >= report_bytes_target:
                 now = time.time()
 
@@ -170,6 +250,8 @@ def verify(input_gen, report_interval=REPORT_INTERVAL):
                 total_bytes = 0
                 total_count = 0
                 report_count = 0
+                total_msg_bytes = 0
+                total_payload_bytes = 0
 
                 print "\n+++ verify-loader"
 
@@ -179,17 +261,23 @@ def verify(input_gen, report_interval=REPORT_INTERVAL):
                         print "%s: %d %d %d" % (invocid, ctx.count, ctx.skips, ctx.duplicates)
                     total_bytes += ctx.bytes
                     total_count += ctx.count
+                    total_msg_bytes += ctx.msg_bytes
+                    total_payload_bytes += ctx.payload_bytes
 
-                print "interval read rate: %.3f MB/sec, %.3f/sec " \
+                print "interval read rate: %.3f MB/sec, %.3f/sec; message %.3f MB/sec; payload %.3f MB/sec " \
                       "(ignored %.3f MB/sec, %.3f/sec); " \
-                      "overall read rate: %.3f MB/sec %.3f/sec " \
+                      "overall read rate: %.3f MB/sec %.3f/sec; message %.3f MB/sec; payload %.3f MB/sec " \
                       "(ignored %.3f MB/sec, %.3f/sec)" % (
                         (report_bytes / MB) / (now - report_start),
                         (report_count / (now - report_start)),
+                        (report_msg_bytes / MB) / (now - report_start),
+                        (report_payload_bytes / MB) / (now - report_start),
                         (report_ignored_bytes / MB) / (now - report_start),
                         (report_ignored_count / (now - report_start)),
                         (total_bytes / MB) / (now - start),
                         (total_count / (now - start)),
+                        (total_msg_bytes / MB) / (now - start),
+                        (total_payload_bytes / MB) / (now - start),
                         (ignored_bytes / MB) / (now - start),
                         (ignored_count / (now - start)))
                 print "--- verify-loader\n"
@@ -197,6 +285,8 @@ def verify(input_gen, report_interval=REPORT_INTERVAL):
 
                 report_bytes = 0
                 report_count = 0
+                report_msg_bytes = 0
+                report_payload_bytes = 0
                 report_ignored_bytes = 0
                 report_ignored_count = 0
                 report_start = now
@@ -210,20 +300,28 @@ def verify(input_gen, report_interval=REPORT_INTERVAL):
         total_count = 0
         tot_skips = 0
         tot_dupes = 0
+        total_msg_bytes = 0
+        total_payload_bytes = 0
+
         for invocid, ctx in contexts.items():
             ctx.report()
             total_bytes += ctx.bytes
             total_count += ctx.count
             tot_skips += ctx.skips
             tot_dupes += ctx.duplicates
+            total_msg_bytes += ctx.msg_bytes
+            total_payload_bytes += ctx.payload_bytes
+
         if ignored_count + total_count > 0:
             print "\n+++ verify-loader"
             for invocid, ctx in contexts.items():
                 print "%s: %d %d %d" % (invocid, ctx.count, ctx.skips, ctx.duplicates)
-            print "overall read rate: %.3f MB/sec %.3f/sec " \
+            print "overall read rate: %.3f MB/sec %.3f/sec; message %.3f MB/sec; payload %.3f MB/sec " \
                   "(ignored %.3f MB/sec, %.3f/sec)" % (
                     (total_bytes / MB) / (now - start),
                     (total_count / (now - start)),
+                    (total_msg_bytes / MB) / (now - start),
+                    (total_payload_bytes / MB) / (now - start),
                     (ignored_bytes / MB) / (now - start),
                     (ignored_count / (now - start)))
             print "--- verify-loader\n"


### PR DESCRIPTION
Adds the `--match-substring` flag.  If this is set, it will look
for the `loader seq - ` token not just at the beginning of each
line, and will handle extra characters at the end of the payload.
For example, a message might look like this:

    <14>1 Mar  1 00:01:40 oshift-origin-dev.oshift-origin-dev.test ocp.test.container: \
    { "kubernetes": { "namespace_id": "7e2a4b16-1914-11e8-8e79-545200c12c31",
    ..., "message": "loader seq - 6eaf4b53a1b44c10a7930c7e37a322d0 - 0000000010 - 8d66a0.....9aab3", "@timestamp": "2018-03-01T00:01:40.883915+00:00" }

This patch handles the `(stats` embedded information too.