### PR TITLE
Adding an option --log-format to loader.

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -15,4 +15,4 @@ RUN chmod +x /loader
 # docker logs $contid
 # docker stop $contid
 # docker rm $contid
-CMD /loader --msgpersec=${MSGPERSEC} --report-interval=${REPORT_INTERVAL} --total-size=${TOTAL_SIZE} --distribution=${DISTRIBUTION} --payload-gen=${PAYLOAD_GEN} --stddev=${STDDEV} --output=${OUTPUT} --report=${REPORT} ${PAYLOAD_SIZE}
+CMD /loader --msgpersec=${MSGPERSEC} --report-interval=${REPORT_INTERVAL} --total-size=${TOTAL_SIZE} --distribution=${DISTRIBUTION} --payload-gen=${PAYLOAD_GEN} --stddev=${STDDEV} --output=${OUTPUT} --report=${REPORT} --log-format=${LOGFORMAT} ${PAYLOAD_SIZE} 

--- a/loader
+++ b/loader
@@ -172,6 +172,53 @@ def load(invocid, size, output_method, report_method, dist='gaussian', stddev=DE
                 report_method("loader stat: %s" % stats.statstr(seq_width))
             break
 
+def jsonload(invocid, size, output_method, report_method, dist='gaussian', stddev=DEFAULT_STDDEV, report_interval=10, seq_width=10, msgpersec=0, total_size=0, payload_gen='random'):
+    '''Emit a formatted payload of random bytes, using a Gaussian
+       distribution using a given size as the mean.  The payload
+       is emitted using the output_method function, while statistics
+       about the output rate are reported through the report_method.
+
+       The reports are generated once every 10,000 payloads, no
+       more than once a second by default. Both parameters can be
+       changed by the caller.
+
+       The generated sequence number defaults to a width of 10.
+
+       The invocation ID, invocid, is required from the caller to
+       facilitate finding the output emitted by this instance.
+    '''
+    msgsizgen = dist_methods[dist]
+    payloadgen = gen_methods[payload_gen]
+    sep = ' - '
+    sep_len = len(sep)
+    prefix = '{"message":"loader seq - %s - ' % invocid
+    prefix_len = len(prefix)
+    sub_len = (prefix_len + seq_width + sep_len)
+
+    stats = StatsCtx(msgpersec, report_interval)
+    for asize, seq, report in msgsizgen(stats, size, stddev):
+        asize -= sub_len
+        if report_method is None and (report or (total_size > 0 and stats.total_size > total_size * (1024 * 1024))):
+            # Reporting is done inline as part of a sequence message payload.
+            stats_msg = "(stats: %s) " % stats.statstr(seq_width)
+            stats_msg_len = len(stats_msg)
+        else:
+            stats_msg = ""
+            stats_msg_len = 0
+        asize -= stats_msg_len
+        asize = 1 if asize <= 0 else asize
+        msg = stats_msg + payloadgen(asize)
+        output_method('%s%0*d%s%s"}' % (prefix, seq_width, seq, sep, msg))
+        if report_method is not None and report:
+            # Reporting is done out-of-band.
+            report_method("loader stat: %s" % stats.statstr(seq_width))
+        if total_size > 0 and (stats.total_size > total_size * (1024 * 1024)):
+            # We're done
+            if report_method is not None and not report:
+                # Reporting is done out-of-band.
+                report_method("loader stat: %s" % stats.statstr(seq_width))
+            break
+
 
 if __name__ == '__main__':
     log = logging.getLogger(__name__)
@@ -191,7 +238,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Message payload generator.')
     parser.add_argument('payload_size', metavar='SIZE', type=int, nargs='?',
             default=1024,
-			help='an integer specifying the mean size of the payload using a Gaussian distribution')
+            help='an integer specifying the mean size of the payload using a Gaussian distribution')
     parser.add_argument('--distribution', metavar='DIST', dest='payload_dist', action='store',
             default='gaussian', choices=dist_methods,
             help='the size distribution to use, e.g. "gaussian" (default), "normal" (alias for gaussian), or "fixed"')
@@ -200,7 +247,7 @@ if __name__ == '__main__':
             help='the payload generator to use, e.g. "random" (default), or "fixed"')
     parser.add_argument('--invocid', metavar='INVOCID', dest='invocid', action='store',
             default=uuid.uuid4().hex,
-			help='the unique invocation ID string to use (defaults to 32 char generated one)')
+            help='the unique invocation ID string to use (defaults to 32 char generated one)')
     parser.add_argument('--stddev', metavar='STDDEV', dest='stddev', type=float,
             default=DEFAULT_STDDEV,
             help='the standard deviation to use with a random distribution (defaults to 32)')
@@ -219,6 +266,9 @@ if __name__ == '__main__':
     parser.add_argument('--total-size', metavar='TOTSIZE', dest='totalsize', type=int,
             default=0,
             help='the total # of megabytes to generate before ending (defaults to 0, unlimited)')
+    parser.add_argument('--log-format', metavar='LOGFORMAT', dest='log_format', action='store',
+            default='string', 
+            help='the format of the "log" value; specify "string" or "json" (defaults to string)')
     args = parser.parse_args()
 
     # Determine the output method to emit logs
@@ -254,7 +304,13 @@ if __name__ == '__main__':
         report_method = report_closure
 
     try:
-        load(args.invocid, args.payload_size, output_method, report_method,
+        if args.log_format == "json":
+            jsonload(args.invocid, args.payload_size, output_method, report_method,
+                dist=args.payload_dist, stddev=args.stddev, msgpersec=args.msgpersec,
+                report_interval=args.reportint, total_size=args.totalsize,
+                payload_gen=args.payload_gen)
+        else:
+            load(args.invocid, args.payload_size, output_method, report_method,
                 dist=args.payload_dist, stddev=args.stddev, msgpersec=args.msgpersec,
                 report_interval=args.reportint, total_size=args.totalsize,
                 payload_gen=args.payload_gen)


### PR DESCRIPTION
  --log-format LOGFORMAT
        the format of the "log" value; specify "string" or "json"
        (defaults to string)

Sample log with "--json-format json"
{"log":"{\"message\":\"loader seq - a0bb3e8de2f140d9af3ed249371b2ef2 - 0000030458 - cde8h5ggqb.....ru196en365k\"}\n","stream":"stdout","time":"2018-07-23T20:12:20.747417064Z"}